### PR TITLE
Test transpose

### DIFF
--- a/run.py
+++ b/run.py
@@ -29,7 +29,7 @@ def monitor_process(cmd):
         pass
 
     for line in lines(proc.stderr):
-        print(colorama.FG.RED + ST.BRIGHT + line + ST.RESET_ALL)
+        print(FG.RED + ST.BRIGHT + line + ST.RESET_ALL)
 
     proc.wait()
     return proc

--- a/test-transpose.py
+++ b/test-transpose.py
@@ -1,0 +1,47 @@
+import sys
+import numpy as np
+import tifffile
+from gi.repository import Ufo
+
+
+def make_input(width, height):
+    return np.arange(width * height, dtype=np.float32).reshape(height, width)
+
+
+def transpose_numpy(width, height, path):
+    image = make_input(width, height)
+    tifffile.imsave(path, image.T)
+
+
+def transpose_ufo(width, height, path):
+    pm = Ufo.PluginManager()
+    graph = Ufo.TaskGraph()
+    sched = Ufo.Scheduler()
+    input_path = 'data/transpose.tif'
+
+    image = make_input(width, height)
+    tifffile.imsave(input_path, image)
+
+    reader = pm.get_task('read')
+    transpose = pm.get_task('transpose')
+    writer = pm.get_task('write')
+
+    reader.props.path = input_path
+    writer.props.filename = path
+
+    graph.connect_nodes(reader, transpose)
+    graph.connect_nodes(transpose, writer)
+    sched.run(graph)
+
+
+def main():
+    path_numpy, path_ufo, width, height = sys.argv[1:]
+    width = int(width)
+    height = int(height)
+
+    transpose_numpy(width, height, path_numpy)
+    transpose_ufo(width, height, path_ufo)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests.json
+++ b/tests.json
@@ -30,5 +30,15 @@
         "params": {},
         "command" : "ufo-launch read path=data/test-stripe-removal-input.tif ! fft dimensions=2 ! filter-stripes ! ifft dimensions=2 ! crop height=3000 width=825 ! write filename=${output}",
         "epsilon": [0.07]
+    },
+    {
+        "name": "transpose",
+        "params": {
+            "width": [1, 7, 128, 145],
+            "height": [1, 7, 128, 145]
+        },
+        "command" : "python test-transpose.py ${reference} ${output} ${width} ${height}",
+        "epsilon": [null, null, null, null, null, null, null, null, null, null, null, null,
+                    null, null, null, null]
     }
 ]


### PR DESCRIPTION
the nulls in epsilon are a bit cumbersome, more so for many-parameter tests. Would be good to have python-like support in json like 16 * [null].